### PR TITLE
chore(sync): update crates from ante-internal

### DIFF
--- a/crates/exec/Cargo.toml
+++ b/crates/exec/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ante-exec"
+version = "0.1.0"
+edition = "2024"
+description = "Standalone process execution utilities for Ante"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["process", "sync", "time", "rt", "macros", "io-util", "fs"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+pretty_assertions = "1"
+tempfile = "3"

--- a/crates/exec/src/buffer.rs
+++ b/crates/exec/src/buffer.rs
@@ -1,0 +1,231 @@
+use std::collections::VecDeque;
+
+/// Byte buffer that preserves the beginning and end, dropping the middle.
+#[derive(Debug, Clone)]
+pub struct HeadTailBuffer {
+    max_bytes: usize,
+    head: VecDeque<Vec<u8>>,
+    tail: VecDeque<Vec<u8>>,
+    head_bytes: usize,
+    tail_bytes: usize,
+    omitted_bytes: usize,
+}
+
+impl HeadTailBuffer {
+    pub fn new(max_bytes: usize) -> Self {
+        Self {
+            max_bytes,
+            head: VecDeque::new(),
+            tail: VecDeque::new(),
+            head_bytes: 0,
+            tail_bytes: 0,
+            omitted_bytes: 0,
+        }
+    }
+
+    pub fn push_chunk(&mut self, chunk: Vec<u8>) {
+        if chunk.is_empty() {
+            return;
+        }
+
+        if self.max_bytes == 0 {
+            self.omitted_bytes += chunk.len();
+            return;
+        }
+
+        let mut chunk = chunk;
+        let head_budget = self.max_bytes / 2;
+        let tail_budget = self.max_bytes - head_budget;
+
+        if self.head_bytes < head_budget {
+            let to_head = (head_budget - self.head_bytes).min(chunk.len());
+            let head_part = chunk.drain(..to_head).collect::<Vec<_>>();
+            self.head_bytes += head_part.len();
+            self.head.push_back(head_part);
+        }
+
+        if chunk.is_empty() {
+            return;
+        }
+
+        if tail_budget == 0 {
+            self.omitted_bytes += chunk.len();
+            return;
+        }
+
+        if chunk.len() > tail_budget {
+            self.omitted_bytes += chunk.len() - tail_budget;
+            let split_at = chunk.len() - tail_budget;
+            chunk = chunk.split_off(split_at);
+
+            self.omitted_bytes += self.tail_bytes;
+            self.tail.clear();
+            self.tail_bytes = 0;
+        } else {
+            self.trim_tail_for(chunk.len(), tail_budget);
+        }
+
+        self.tail_bytes += chunk.len();
+        self.tail.push_back(chunk);
+    }
+
+    pub fn snapshot(&self) -> Vec<Vec<u8>> {
+        let mut out = Vec::with_capacity(self.head.len() + self.tail.len());
+        out.extend(self.head.iter().cloned());
+        out.extend(self.tail.iter().cloned());
+        out
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.retained_bytes());
+        for chunk in &self.head {
+            out.extend_from_slice(chunk);
+        }
+        for chunk in &self.tail {
+            out.extend_from_slice(chunk);
+        }
+        out
+    }
+
+    pub fn drain(&mut self) -> Vec<Vec<u8>> {
+        let mut out = Vec::with_capacity(self.head.len() + self.tail.len());
+        while let Some(chunk) = self.head.pop_front() {
+            out.push(chunk);
+        }
+        while let Some(chunk) = self.tail.pop_front() {
+            out.push(chunk);
+        }
+
+        self.clear();
+        out
+    }
+
+    pub fn drain_into(&mut self, target: &mut HeadTailBuffer) {
+        while let Some(chunk) = self.head.pop_front() {
+            target.push_chunk(chunk);
+        }
+        while let Some(chunk) = self.tail.pop_front() {
+            target.push_chunk(chunk);
+        }
+
+        self.clear();
+    }
+
+    fn clear(&mut self) {
+        self.head.clear();
+        self.tail.clear();
+        self.head_bytes = 0;
+        self.tail_bytes = 0;
+        self.omitted_bytes = 0;
+    }
+
+    pub fn retained_bytes(&self) -> usize {
+        self.head_bytes + self.tail_bytes
+    }
+
+    pub fn omitted_bytes(&self) -> usize {
+        self.omitted_bytes
+    }
+
+    fn trim_tail_for(&mut self, incoming_bytes: usize, tail_budget: usize) {
+        while self.tail_bytes + incoming_bytes > tail_budget {
+            let overflow = self.tail_bytes + incoming_bytes - tail_budget;
+            let Some(front) = self.tail.front_mut() else {
+                break;
+            };
+
+            if front.len() <= overflow {
+                let removed = front.len();
+                self.tail.pop_front();
+                self.tail_bytes -= removed;
+                self.omitted_bytes += removed;
+                continue;
+            }
+
+            front.drain(..overflow);
+            self.tail_bytes -= overflow;
+            self.omitted_bytes += overflow;
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HeadTailBuffer;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn retains_all_output_when_under_budget() {
+        let mut buffer = HeadTailBuffer::new(16);
+        buffer.push_chunk(b"hello".to_vec());
+        buffer.push_chunk(b" world".to_vec());
+
+        assert_eq!(buffer.to_bytes(), b"hello world".to_vec());
+        assert_eq!(buffer.retained_bytes(), 11);
+        assert_eq!(buffer.omitted_bytes(), 0);
+    }
+
+    #[test]
+    fn preserves_head_and_tail_when_over_budget() {
+        let mut buffer = HeadTailBuffer::new(12);
+        buffer.push_chunk(b"abcdef".to_vec());
+        buffer.push_chunk(b"ghij".to_vec());
+        buffer.push_chunk(b"klmnop".to_vec());
+
+        assert_eq!(buffer.to_bytes(), b"abcdefklmnop".to_vec());
+        assert_eq!(buffer.retained_bytes(), 12);
+        assert_eq!(buffer.omitted_bytes(), 4);
+    }
+
+    #[test]
+    fn large_chunk_keeps_only_tail_suffix() {
+        let mut buffer = HeadTailBuffer::new(10);
+        buffer.push_chunk(b"abcde".to_vec());
+        buffer.push_chunk(b"0123456789".to_vec());
+
+        assert_eq!(buffer.to_bytes(), b"abcde56789".to_vec());
+        assert_eq!(buffer.retained_bytes(), 10);
+        assert_eq!(buffer.omitted_bytes(), 5);
+    }
+
+    #[test]
+    fn zero_budget_omits_everything() {
+        let mut buffer = HeadTailBuffer::new(0);
+        buffer.push_chunk(b"abcdef".to_vec());
+
+        assert_eq!(buffer.to_bytes(), Vec::<u8>::new());
+        assert_eq!(buffer.retained_bytes(), 0);
+        assert_eq!(buffer.omitted_bytes(), 6);
+    }
+
+    #[test]
+    fn drain_returns_chunks_and_resets_state() {
+        let mut buffer = HeadTailBuffer::new(8);
+        buffer.push_chunk(b"abcd".to_vec());
+        buffer.push_chunk(b"efgh".to_vec());
+
+        let drained = buffer.drain();
+        let drained_bytes = drained.concat();
+        assert_eq!(drained_bytes, b"abcdefgh".to_vec());
+
+        assert_eq!(buffer.retained_bytes(), 0);
+        assert_eq!(buffer.omitted_bytes(), 0);
+        assert_eq!(buffer.snapshot(), Vec::<Vec<u8>>::new());
+    }
+
+    #[test]
+    fn drain_into_moves_chunks_without_intermediate_snapshot() {
+        let mut source = HeadTailBuffer::new(8);
+        let mut target = HeadTailBuffer::new(16);
+        source.push_chunk(b"abcd".to_vec());
+        source.push_chunk(b"efgh".to_vec());
+
+        source.drain_into(&mut target);
+
+        assert_eq!(target.to_bytes(), b"abcdefgh".to_vec());
+        assert_eq!(source.retained_bytes(), 0);
+        assert_eq!(source.omitted_bytes(), 0);
+        assert_eq!(source.snapshot(), Vec::<Vec<u8>>::new());
+    }
+}

--- a/crates/exec/src/handle.rs
+++ b/crates/exec/src/handle.rs
@@ -1,0 +1,103 @@
+use anyhow::{Result, anyhow};
+use std::sync::{Arc, Mutex as StdMutex};
+use tokio::sync::{Notify, broadcast, mpsc};
+
+use crate::lock_or_recover;
+
+pub(crate) const OUTPUT_CHANNEL_CAPACITY: usize = 256;
+pub(crate) const STDIN_CHANNEL_CAPACITY: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Stream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OutputChunk {
+    pub stream: Stream,
+    pub data: Vec<u8>,
+}
+
+/// Handle + a pre-subscribed receiver that won't miss early output.
+pub type SpawnedProcess = (ProcessHandle, broadcast::Receiver<OutputChunk>);
+
+pub(crate) trait ChildTerminator: Send + 'static {
+    fn terminate(&mut self);
+}
+
+/// Thin process lifecycle handle.
+pub struct ProcessHandle {
+    output_tx: broadcast::Sender<OutputChunk>,
+    writer: Option<mpsc::Sender<Vec<u8>>>,
+    exit_code: Arc<StdMutex<Option<i32>>>,
+    exit_notify: Arc<Notify>,
+    terminator: StdMutex<Option<Box<dyn ChildTerminator>>>,
+}
+
+impl ProcessHandle {
+    pub(crate) fn from_parts(
+        output_tx: broadcast::Sender<OutputChunk>,
+        writer: Option<mpsc::Sender<Vec<u8>>>,
+        exit_code: Arc<StdMutex<Option<i32>>>,
+        exit_notify: Arc<Notify>,
+        terminator: Box<dyn ChildTerminator>,
+    ) -> Self {
+        Self {
+            output_tx,
+            writer,
+            exit_code,
+            exit_notify,
+            terminator: StdMutex::new(Some(terminator)),
+        }
+    }
+
+    /// Write bytes to the child's stdin. Errors if stdin was not piped.
+    pub async fn write_stdin(&self, data: &[u8]) -> Result<()> {
+        let writer =
+            self.writer.as_ref().ok_or_else(|| anyhow!("stdin was not piped for this process"))?;
+        writer
+            .send(data.to_vec())
+            .await
+            .map_err(|_| anyhow!("stdin is closed for this process"))?;
+        Ok(())
+    }
+
+    /// Subscribe to the raw output stream.
+    pub fn output_subscribe(&self) -> broadcast::Receiver<OutputChunk> {
+        self.output_tx.subscribe()
+    }
+
+    /// Wait until the process exits.
+    pub async fn wait_for_exit(&self) {
+        loop {
+            if self.has_exited() {
+                return;
+            }
+            // Acquire the waiter before checking again to avoid missing a notify.
+            let notified = self.exit_notify.notified();
+            if self.has_exited() {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    /// True if the child has exited.
+    pub fn has_exited(&self) -> bool {
+        lock_or_recover(&self.exit_code).is_some()
+    }
+
+    /// Exit code, if exited.
+    pub fn exit_code(&self) -> Option<i32> {
+        *lock_or_recover(&self.exit_code)
+    }
+
+    /// Kill the child and all descendants. Idempotent.
+    pub fn terminate(&self) {
+        let mut guard = lock_or_recover(&self.terminator);
+        if let Some(mut terminator) = guard.take() {
+            terminator.terminate();
+        }
+    }
+}

--- a/crates/exec/src/lib.rs
+++ b/crates/exec/src/lib.rs
@@ -1,0 +1,26 @@
+use std::sync::{Mutex, MutexGuard};
+
+pub mod buffer;
+pub mod handle;
+pub mod pool;
+pub mod process_group;
+pub mod receiver;
+pub mod subprocess;
+
+pub use buffer::HeadTailBuffer;
+pub use handle::{OutputChunk, ProcessHandle, SpawnedProcess, Stream};
+pub use pool::{
+    ExecError, ExecRequest, ExecResponse, PollRequest, PoolConfig, ProcessPool, StdinRequest,
+};
+pub use receiver::OutputReceiver;
+pub use subprocess::{CommandOptions, RunOutput, StdinMode, run_with_timeout};
+
+pub(crate) fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/exec/src/pool.rs
+++ b/crates/exec/src/pool.rs
@@ -1,0 +1,531 @@
+use crate::handle::{OutputChunk, ProcessHandle, SpawnedProcess, Stream};
+use crate::{CommandOptions, HeadTailBuffer, lock_or_recover, subprocess};
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+use tokio::sync::{Mutex, Notify, broadcast};
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, sleep_until};
+
+const EXIT_DRAIN_GRACE: Duration = Duration::from_millis(50);
+const RECENT_PROTECTION_COUNT: usize = 8;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PoolConfig {
+    pub max_processes: usize,
+    pub max_output_bytes: usize,
+    pub default_yield_ms: u64,
+    pub max_yield_ms: u64,
+    pub background_timeout_ms: u64,
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        Self {
+            max_processes: 64,
+            max_output_bytes: 1024 * 1024,
+            default_yield_ms: 250,
+            max_yield_ms: 30_000,
+            background_timeout_ms: 300_000,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ExecRequest {
+    pub command: CommandOptions,
+    pub yield_time_ms: u64,
+    pub max_output_bytes: Option<usize>,
+}
+
+impl ExecRequest {
+    pub fn new(command: CommandOptions) -> Self {
+        Self { command, yield_time_ms: 0, max_output_bytes: None }
+    }
+
+    pub fn with_yield_time_ms(mut self, yield_time_ms: u64) -> Self {
+        self.yield_time_ms = yield_time_ms;
+        self
+    }
+
+    pub fn with_max_output_bytes(mut self, max_output_bytes: usize) -> Self {
+        self.max_output_bytes = Some(max_output_bytes);
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PollRequest<'a> {
+    pub process_id: &'a str,
+    pub yield_time_ms: u64,
+    pub max_output_bytes: Option<usize>,
+}
+
+impl<'a> PollRequest<'a> {
+    pub fn new(process_id: &'a str) -> Self {
+        Self { process_id, yield_time_ms: 0, max_output_bytes: None }
+    }
+
+    pub fn with_yield_time_ms(mut self, yield_time_ms: u64) -> Self {
+        self.yield_time_ms = yield_time_ms;
+        self
+    }
+
+    pub fn with_max_output_bytes(mut self, max_output_bytes: usize) -> Self {
+        self.max_output_bytes = Some(max_output_bytes);
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StdinRequest<'a> {
+    pub process_id: &'a str,
+    pub input: &'a [u8],
+    pub yield_time_ms: u64,
+    pub max_output_bytes: Option<usize>,
+}
+
+impl<'a> StdinRequest<'a> {
+    pub fn new(process_id: &'a str, input: &'a [u8]) -> Self {
+        Self { process_id, input, yield_time_ms: 0, max_output_bytes: None }
+    }
+
+    pub fn with_yield_time_ms(mut self, yield_time_ms: u64) -> Self {
+        self.yield_time_ms = yield_time_ms;
+        self
+    }
+
+    pub fn with_max_output_bytes(mut self, max_output_bytes: usize) -> Self {
+        self.max_output_bytes = Some(max_output_bytes);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExecResponse {
+    pub output: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub process_id: Option<String>,
+    pub exit_code: Option<i32>,
+    pub wall_time: Duration,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ExecError {
+    SpawnFailed(String),
+    UnknownProcess { process_id: String },
+    StdinClosed,
+    PoolFull,
+}
+
+impl fmt::Display for ExecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SpawnFailed(message) => write!(f, "failed to spawn process: {message}"),
+            Self::UnknownProcess { process_id } => write!(f, "unknown process: {process_id}"),
+            Self::StdinClosed => write!(f, "stdin is closed for this process"),
+            Self::PoolFull => write!(f, "process pool is full"),
+        }
+    }
+}
+
+impl Error for ExecError {}
+
+#[derive(Clone)]
+pub struct ProcessPool {
+    inner: Arc<PoolInner>,
+}
+
+struct PoolInner {
+    config: PoolConfig,
+    entries: Mutex<HashMap<String, Arc<ProcessEntry>>>,
+    spawn_gate: Mutex<()>,
+    next_process_id: AtomicU64,
+}
+
+struct ProcessEntry {
+    handle: ProcessHandle,
+    output: StdMutex<HeadTailBuffer>,
+    stderr: StdMutex<HeadTailBuffer>,
+    notify: Arc<Notify>,
+    last_used: StdMutex<Instant>,
+    interaction: Mutex<()>,
+    buffer_task: StdMutex<Option<JoinHandle<()>>>,
+}
+
+impl ProcessPool {
+    pub fn new(config: PoolConfig) -> Self {
+        let default_yield_ms = config.default_yield_ms.max(1);
+        let max_yield_ms = config.max_yield_ms.max(default_yield_ms);
+        let normalized = PoolConfig {
+            max_processes: config.max_processes.max(1),
+            max_output_bytes: config.max_output_bytes,
+            default_yield_ms,
+            max_yield_ms,
+            background_timeout_ms: config.background_timeout_ms.max(1),
+        };
+
+        Self {
+            inner: Arc::new(PoolInner {
+                config: normalized,
+                entries: Mutex::new(HashMap::new()),
+                spawn_gate: Mutex::new(()),
+                next_process_id: AtomicU64::new(1000),
+            }),
+        }
+    }
+
+    pub async fn exec(&self, request: ExecRequest) -> Result<ExecResponse, ExecError> {
+        let _spawn_guard = self.inner.spawn_gate.lock().await;
+        self.ensure_capacity().await?;
+
+        let process_id = self.next_process_id();
+        let entry = ProcessEntry::new(
+            subprocess::spawn(request.command)
+                .await
+                .map_err(|err| ExecError::SpawnFailed(err.to_string()))?,
+            self.inner.config.max_output_bytes,
+        );
+
+        self.inner.entries.lock().await.insert(process_id.clone(), Arc::clone(&entry));
+        drop(_spawn_guard);
+
+        self.interact(&entry, &process_id, None, request.yield_time_ms, request.max_output_bytes)
+            .await
+    }
+
+    pub async fn poll_output(&self, request: PollRequest<'_>) -> Result<ExecResponse, ExecError> {
+        self.prune_expired_entries().await;
+        let entry = self.entry(request.process_id).await?;
+        self.interact(
+            &entry,
+            request.process_id,
+            None,
+            request.yield_time_ms,
+            request.max_output_bytes,
+        )
+        .await
+    }
+
+    pub async fn write_stdin(&self, request: StdinRequest<'_>) -> Result<ExecResponse, ExecError> {
+        self.prune_expired_entries().await;
+        let entry = self.entry(request.process_id).await?;
+        self.interact(
+            &entry,
+            request.process_id,
+            Some(request.input),
+            request.yield_time_ms,
+            request.max_output_bytes,
+        )
+        .await
+    }
+
+    pub async fn kill(&self, process_id: &str) -> Result<(), ExecError> {
+        let removed = self.inner.entries.lock().await.remove(process_id);
+        let Some(entry) = removed else {
+            return Err(ExecError::UnknownProcess { process_id: process_id.to_string() });
+        };
+
+        shutdown_entry(entry, true);
+        Ok(())
+    }
+
+    pub async fn terminate_all(&self) {
+        let removed =
+            self.inner.entries.lock().await.drain().map(|(_, entry)| entry).collect::<Vec<_>>();
+        for entry in removed {
+            shutdown_entry(entry, true);
+        }
+    }
+
+    async fn interact(
+        &self,
+        entry: &Arc<ProcessEntry>,
+        process_id: &str,
+        input: Option<&[u8]>,
+        yield_time_ms: u64,
+        max_output_bytes: Option<usize>,
+    ) -> Result<ExecResponse, ExecError> {
+        let _interaction_guard = entry.interaction.lock().await;
+        entry.touch();
+
+        let stdin_closed = match input {
+            Some(input) => entry.handle.write_stdin(input).await.is_err(),
+            None => false,
+        };
+
+        if stdin_closed {
+            if entry.handle.has_exited() {
+                self.remove_if_same(process_id, entry, false).await;
+            }
+            return Err(ExecError::StdinClosed);
+        }
+
+        let response =
+            self.collect_locked(entry, process_id, yield_time_ms, max_output_bytes).await;
+
+        if response.process_id.is_none() {
+            self.remove_if_same(process_id, entry, false).await;
+        }
+
+        Ok(response)
+    }
+
+    async fn collect_locked(
+        &self,
+        entry: &Arc<ProcessEntry>,
+        process_id: &str,
+        yield_time_ms: u64,
+        max_output_bytes: Option<usize>,
+    ) -> ExecResponse {
+        let started = Instant::now();
+        let deadline =
+            Instant::now() + Duration::from_millis(self.normalize_yield_ms(yield_time_ms));
+        let output_limit = self.normalize_output_bytes(max_output_bytes);
+        let mut output = HeadTailBuffer::new(output_limit);
+        let mut stderr = HeadTailBuffer::new(output_limit);
+        let mut exit_grace_deadline = None;
+
+        loop {
+            entry.drain_into(&mut output, &mut stderr);
+
+            let now = Instant::now();
+            if let Some(grace_deadline) = exit_grace_deadline {
+                if now >= grace_deadline {
+                    break;
+                }
+            } else if entry.handle.has_exited() {
+                exit_grace_deadline = Some(deadline.min(now + EXIT_DRAIN_GRACE));
+            } else if now >= deadline {
+                break;
+            }
+
+            let wait_until = exit_grace_deadline.unwrap_or(deadline);
+            if Instant::now() >= wait_until {
+                continue;
+            }
+
+            let notified = entry.notify.notified();
+            tokio::pin!(notified);
+
+            tokio::select! {
+                _ = &mut notified => {}
+                _ = entry.handle.wait_for_exit(), if exit_grace_deadline.is_none() => {
+                    exit_grace_deadline = Some(deadline.min(Instant::now() + EXIT_DRAIN_GRACE));
+                }
+                _ = sleep_until(wait_until) => {
+                    break;
+                }
+            }
+        }
+
+        entry.touch();
+        let exit_code = entry.handle.exit_code();
+        let process_id =
+            if entry.handle.has_exited() { None } else { Some(process_id.to_string()) };
+
+        ExecResponse {
+            output: output.to_bytes(),
+            stderr: stderr.to_bytes(),
+            process_id,
+            exit_code,
+            wall_time: started.elapsed(),
+        }
+    }
+
+    async fn entry(&self, process_id: &str) -> Result<Arc<ProcessEntry>, ExecError> {
+        self.inner
+            .entries
+            .lock()
+            .await
+            .get(process_id)
+            .cloned()
+            .ok_or_else(|| ExecError::UnknownProcess { process_id: process_id.to_string() })
+    }
+
+    async fn ensure_capacity(&self) -> Result<(), ExecError> {
+        let mut removed = self.take_expired_entries().await;
+        {
+            let mut entries = self.inner.entries.lock().await;
+            while entries.len() >= self.inner.config.max_processes {
+                let Some(process_id) = eviction_candidate(&entries) else {
+                    break;
+                };
+
+                if let Some(entry) = entries.remove(&process_id) {
+                    removed.push(entry);
+                }
+            }
+
+            if entries.len() >= self.inner.config.max_processes {
+                return Err(ExecError::PoolFull);
+            }
+        }
+
+        shutdown_entries(removed, true);
+
+        Ok(())
+    }
+
+    async fn prune_expired_entries(&self) {
+        shutdown_entries(self.take_expired_entries().await, true);
+    }
+
+    async fn remove_if_same(
+        &self,
+        process_id: &str,
+        expected: &Arc<ProcessEntry>,
+        terminate: bool,
+    ) {
+        let removed = {
+            let mut entries = self.inner.entries.lock().await;
+            match entries.get(process_id) {
+                Some(entry) if Arc::ptr_eq(entry, expected) => entries.remove(process_id),
+                _ => None,
+            }
+        };
+
+        if let Some(entry) = removed {
+            shutdown_entry(entry, terminate);
+        }
+    }
+
+    fn next_process_id(&self) -> String {
+        self.inner.next_process_id.fetch_add(1, Ordering::Relaxed).to_string()
+    }
+
+    fn normalize_output_bytes(&self, max_output_bytes: Option<usize>) -> usize {
+        max_output_bytes
+            .unwrap_or(self.inner.config.max_output_bytes)
+            .min(self.inner.config.max_output_bytes)
+    }
+
+    fn normalize_yield_ms(&self, yield_time_ms: u64) -> u64 {
+        let yield_time_ms =
+            if yield_time_ms == 0 { self.inner.config.default_yield_ms } else { yield_time_ms };
+
+        yield_time_ms.clamp(self.inner.config.default_yield_ms, self.inner.config.max_yield_ms)
+    }
+
+    async fn take_expired_entries(&self) -> Vec<Arc<ProcessEntry>> {
+        let timeout = Duration::from_millis(self.inner.config.background_timeout_ms);
+        let now = Instant::now();
+        let mut entries = self.inner.entries.lock().await;
+        let expired_ids = entries
+            .iter()
+            .filter(|(_, entry)| now.duration_since(entry.last_used()) > timeout)
+            .map(|(process_id, _)| process_id.clone())
+            .collect::<Vec<_>>();
+
+        expired_ids.into_iter().filter_map(|process_id| entries.remove(&process_id)).collect()
+    }
+}
+
+impl ProcessEntry {
+    fn new(spawned: SpawnedProcess, max_output_bytes: usize) -> Arc<Self> {
+        let (handle, rx) = spawned;
+        let entry = Arc::new(Self {
+            handle,
+            output: StdMutex::new(HeadTailBuffer::new(max_output_bytes)),
+            stderr: StdMutex::new(HeadTailBuffer::new(max_output_bytes)),
+            notify: Arc::new(Notify::new()),
+            last_used: StdMutex::new(Instant::now()),
+            interaction: Mutex::new(()),
+            buffer_task: StdMutex::new(None),
+        });
+
+        let task_entry = Arc::clone(&entry);
+        let task = tokio::spawn(async move {
+            task_entry.buffer_output(rx).await;
+        });
+        *lock_or_recover(&entry.buffer_task) = Some(task);
+
+        entry
+    }
+
+    async fn buffer_output(self: Arc<Self>, mut rx: broadcast::Receiver<OutputChunk>) {
+        loop {
+            match rx.recv().await {
+                Ok(chunk) => {
+                    self.push_chunk(chunk);
+                    self.notify.notify_waiters();
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return,
+            }
+        }
+    }
+
+    fn push_chunk(&self, chunk: OutputChunk) {
+        let OutputChunk { stream, data } = chunk;
+
+        if stream == Stream::Stderr {
+            lock_or_recover(&self.stderr).push_chunk(data.clone());
+        }
+
+        lock_or_recover(&self.output).push_chunk(data);
+    }
+
+    fn drain_into(&self, output: &mut HeadTailBuffer, stderr: &mut HeadTailBuffer) {
+        lock_or_recover(&self.output).drain_into(output);
+        lock_or_recover(&self.stderr).drain_into(stderr);
+    }
+
+    fn touch(&self) {
+        *lock_or_recover(&self.last_used) = Instant::now();
+    }
+
+    fn last_used(&self) -> Instant {
+        *lock_or_recover(&self.last_used)
+    }
+
+    fn abort_buffer_task(&self) {
+        if let Some(task) = lock_or_recover(&self.buffer_task).take() {
+            task.abort();
+        }
+    }
+}
+
+fn eviction_candidate(entries: &HashMap<String, Arc<ProcessEntry>>) -> Option<String> {
+    let mut candidates = entries
+        .iter()
+        .map(|(process_id, entry)| {
+            (process_id.clone(), entry.last_used(), entry.handle.has_exited())
+        })
+        .collect::<Vec<_>>();
+
+    if let Some((process_id, _, _)) = candidates
+        .iter()
+        .filter(|(_, _, exited)| *exited)
+        .min_by_key(|(_, last_used, _)| *last_used)
+    {
+        return Some(process_id.clone());
+    }
+
+    candidates.sort_by_key(|(_, last_used, _)| *last_used);
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let protected = RECENT_PROTECTION_COUNT.min(candidates.len().saturating_sub(1));
+    let unprotected_end = candidates.len().saturating_sub(protected);
+
+    candidates.into_iter().take(unprotected_end).next().map(|(process_id, _, _)| process_id)
+}
+
+fn shutdown_entry(entry: Arc<ProcessEntry>, terminate: bool) {
+    if terminate && !entry.handle.has_exited() {
+        entry.handle.terminate();
+    }
+
+    entry.abort_buffer_task();
+}
+
+fn shutdown_entries(entries: Vec<Arc<ProcessEntry>>, terminate: bool) {
+    for entry in entries {
+        shutdown_entry(entry, terminate);
+    }
+}

--- a/crates/exec/src/process_group.rs
+++ b/crates/exec/src/process_group.rs
@@ -1,0 +1,146 @@
+//! Process-group helpers shared by process execution backends.
+//!
+//! On non-Unix platforms these helpers are no-ops.
+
+use std::io;
+
+#[cfg(target_os = "linux")]
+/// Ensure the child receives SIGTERM when the original parent dies.
+///
+/// This should run in `pre_exec` and uses `parent_pid` captured before spawn to
+/// avoid a race where the parent exits between fork and exec.
+pub fn set_parent_death_signal(parent_pid: libc::pid_t) -> io::Result<()> {
+    if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    if unsafe { libc::getppid() } != parent_pid {
+        unsafe {
+            libc::raise(libc::SIGTERM);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+/// No-op on non-Linux platforms.
+pub fn set_parent_death_signal(_parent_pid: i32) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Detach from the controlling TTY by starting a new session.
+pub fn detach_from_tty() -> io::Result<()> {
+    let result = unsafe { libc::setsid() };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EPERM) {
+            return set_process_group();
+        }
+        return Err(err);
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn detach_from_tty() -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Put the calling process into its own process group.
+///
+/// Intended for use in `pre_exec` so the child becomes the group leader.
+pub fn set_process_group() -> io::Result<()> {
+    let result = unsafe { libc::setpgid(0, 0) };
+    if result == -1 { Err(io::Error::last_os_error()) } else { Ok(()) }
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn set_process_group() -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Resolve a process group by PID and send SIGKILL (best-effort).
+pub(crate) fn kill_process_group_by_pid(pid: u32) -> io::Result<()> {
+    use std::io::ErrorKind;
+
+    let pid = pid as libc::pid_t;
+    let pgid = unsafe { libc::getpgid(pid) };
+    if pgid == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() != ErrorKind::NotFound {
+            return Err(err);
+        }
+        return Ok(());
+    }
+
+    let result = unsafe { libc::killpg(pgid, libc::SIGKILL) };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() != ErrorKind::NotFound {
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn kill_process_group_by_pid(_pid: u32) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Send SIGTERM to a process group.
+///
+/// Returns `Ok(true)` when SIGTERM was delivered to an existing group and
+/// `Ok(false)` when the group no longer exists.
+pub fn terminate_process_group(process_group_id: u32) -> io::Result<bool> {
+    use std::io::ErrorKind;
+
+    let pgid = process_group_id as libc::pid_t;
+    let result = unsafe { libc::killpg(pgid, libc::SIGTERM) };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() == ErrorKind::NotFound {
+            return Ok(false);
+        }
+        return Err(err);
+    }
+
+    Ok(true)
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn terminate_process_group(_process_group_id: u32) -> io::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(unix)]
+/// Send SIGKILL to a process group (best-effort).
+pub fn kill_process_group(process_group_id: u32) -> io::Result<()> {
+    use std::io::ErrorKind;
+
+    let pgid = process_group_id as libc::pid_t;
+    let result = unsafe { libc::killpg(pgid, libc::SIGKILL) };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() != ErrorKind::NotFound {
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn kill_process_group(_process_group_id: u32) -> io::Result<()> {
+    Ok(())
+}

--- a/crates/exec/src/receiver.rs
+++ b/crates/exec/src/receiver.rs
@@ -1,0 +1,56 @@
+use crate::{HeadTailBuffer, OutputChunk};
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::error::{RecvError, TryRecvError};
+
+/// Ergonomic wrapper around a broadcast receiver of process output.
+pub struct OutputReceiver {
+    rx: broadcast::Receiver<OutputChunk>,
+}
+
+impl OutputReceiver {
+    pub fn new(rx: broadcast::Receiver<OutputChunk>) -> Self {
+        Self { rx }
+    }
+
+    /// Receive the next available chunk, skipping lagged messages.
+    pub async fn recv(&mut self) -> Option<OutputChunk> {
+        loop {
+            match self.rx.recv().await {
+                Ok(chunk) => return Some(chunk),
+                Err(RecvError::Lagged(_)) => continue,
+                Err(RecvError::Closed) => return None,
+            }
+        }
+    }
+
+    /// Drain all immediately available chunks without blocking.
+    pub fn try_drain(&mut self) -> Vec<OutputChunk> {
+        let mut drained = Vec::new();
+        self.drain_with(|chunk| drained.push(chunk));
+        drained
+    }
+
+    pub(crate) fn drain_with<F>(&mut self, mut on_chunk: F)
+    where
+        F: FnMut(OutputChunk),
+    {
+        loop {
+            match self.rx.try_recv() {
+                Ok(chunk) => on_chunk(chunk),
+                Err(TryRecvError::Lagged(_)) => continue,
+                Err(TryRecvError::Empty | TryRecvError::Closed) => return,
+            }
+        }
+    }
+
+    /// Drain all immediately available chunks into a buffer, merging streams.
+    pub fn drain_into(&mut self, buf: &mut HeadTailBuffer) {
+        self.drain_with(|chunk| buf.push_chunk(chunk.data));
+    }
+}
+
+impl From<broadcast::Receiver<OutputChunk>> for OutputReceiver {
+    fn from(rx: broadcast::Receiver<OutputChunk>) -> Self {
+        Self::new(rx)
+    }
+}

--- a/crates/exec/src/subprocess.rs
+++ b/crates/exec/src/subprocess.rs
@@ -1,0 +1,305 @@
+use crate::handle::{
+    ChildTerminator, OUTPUT_CHANNEL_CAPACITY, OutputChunk, ProcessHandle, STDIN_CHANNEL_CAPACITY,
+    SpawnedProcess, Stream,
+};
+use crate::process_group;
+use crate::{HeadTailBuffer, OutputReceiver, lock_or_recover};
+use anyhow::{Context, Result, anyhow};
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
+use std::process::{ExitStatus, Stdio};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{Notify, broadcast, mpsc};
+use tokio::time::Instant;
+
+const EXIT_OUTPUT_GRACE: Duration = Duration::from_millis(50);
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum StdinMode {
+    #[default]
+    Piped,
+    Null,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CommandOptions {
+    program: String,
+    args: Vec<String>,
+    cwd: PathBuf,
+    env: HashMap<String, String>,
+    stdin: StdinMode,
+}
+
+impl CommandOptions {
+    pub fn new(program: impl Into<String>, cwd: impl Into<PathBuf>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            cwd: cwd.into(),
+            env: HashMap::new(),
+            stdin: StdinMode::Piped,
+        }
+    }
+
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn envs<I, K, V>(mut self, envs: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.env.extend(envs.into_iter().map(|(key, value)| (key.into(), value.into())));
+        self
+    }
+
+    pub fn stdin(mut self, stdin: StdinMode) -> Self {
+        self.stdin = stdin;
+        self
+    }
+
+    pub fn no_stdin(self) -> Self {
+        self.stdin(StdinMode::Null)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RunOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub stdout_omitted_bytes: usize,
+    pub stderr_omitted_bytes: usize,
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+    pub wall_time: Duration,
+}
+
+pub async fn run_with_timeout(
+    options: CommandOptions,
+    timeout: Duration,
+    max_output_bytes: usize,
+) -> Result<RunOutput> {
+    let started = Instant::now();
+    let (handle, rx) = spawn(options).await?;
+    let mut receiver = OutputReceiver::from(rx);
+    let mut stdout = HeadTailBuffer::new(max_output_bytes);
+    let mut stderr = HeadTailBuffer::new(max_output_bytes);
+    let deadline = Instant::now() + timeout;
+    let timeout_sleep = tokio::time::sleep_until(deadline);
+    tokio::pin!(timeout_sleep);
+    let mut timed_out = false;
+    let mut exit_seen = false;
+
+    loop {
+        drain_receiver(&mut receiver, &mut stdout, &mut stderr);
+
+        if exit_seen {
+            break;
+        }
+
+        if handle.has_exited() {
+            exit_seen = true;
+            tokio::time::sleep(EXIT_OUTPUT_GRACE).await;
+            continue;
+        }
+
+        tokio::select! {
+            chunk = receiver.recv() => {
+                if let Some(chunk) = chunk {
+                    push_output_chunk(chunk, &mut stdout, &mut stderr);
+                }
+            }
+            _ = handle.wait_for_exit() => {
+                exit_seen = true;
+                tokio::time::sleep(EXIT_OUTPUT_GRACE).await;
+            }
+            _ = &mut timeout_sleep => {
+                timed_out = true;
+                handle.terminate();
+                tokio::time::sleep(EXIT_OUTPUT_GRACE).await;
+                break;
+            }
+        }
+    }
+
+    drain_receiver(&mut receiver, &mut stdout, &mut stderr);
+
+    Ok(RunOutput {
+        stdout: stdout.to_bytes(),
+        stderr: stderr.to_bytes(),
+        stdout_omitted_bytes: stdout.omitted_bytes(),
+        stderr_omitted_bytes: stderr.omitted_bytes(),
+        exit_code: if timed_out { None } else { handle.exit_code() },
+        timed_out,
+        wall_time: started.elapsed(),
+    })
+}
+
+pub async fn spawn(options: CommandOptions) -> Result<SpawnedProcess> {
+    let with_stdin = matches!(options.stdin, StdinMode::Piped);
+    let mut command = Command::new(&options.program);
+    command
+        .args(&options.args)
+        .current_dir(&options.cwd)
+        .envs(&options.env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(false);
+
+    if with_stdin {
+        command.stdin(Stdio::piped());
+    } else {
+        command.stdin(Stdio::null());
+    }
+
+    #[cfg(unix)]
+    {
+        let parent_pid = unsafe { libc::getpid() };
+        unsafe {
+            command.pre_exec(move || {
+                process_group::detach_from_tty()?;
+                process_group::set_parent_death_signal(parent_pid)?;
+                Ok(())
+            });
+        }
+    }
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to spawn process `{}`", options.program))?;
+    let pid = child.id().ok_or_else(|| anyhow!("spawned process is missing a pid"))?;
+
+    let writer = if with_stdin { child.stdin.take().map(spawn_stdin_writer) } else { None };
+    let stdout = child.stdout.take().ok_or_else(|| anyhow!("failed to capture stdout"))?;
+    let stderr = child.stderr.take().ok_or_else(|| anyhow!("failed to capture stderr"))?;
+
+    let (output_tx, output_rx) = broadcast::channel(OUTPUT_CHANNEL_CAPACITY);
+    let exit_code = Arc::new(StdMutex::new(None));
+    let exit_notify = Arc::new(Notify::new());
+
+    spawn_reader(stdout, Stream::Stdout, output_tx.clone());
+    spawn_reader(stderr, Stream::Stderr, output_tx.clone());
+    spawn_exit_watcher(child, Arc::clone(&exit_code), Arc::clone(&exit_notify));
+
+    let handle = ProcessHandle::from_parts(
+        output_tx,
+        writer,
+        exit_code,
+        exit_notify,
+        Box::new(PidTerminator { pid }),
+    );
+
+    Ok((handle, output_rx))
+}
+
+fn spawn_stdin_writer(mut stdin: ChildStdin) -> mpsc::Sender<Vec<u8>> {
+    let (tx, mut rx) = mpsc::channel::<Vec<u8>>(STDIN_CHANNEL_CAPACITY);
+    tokio::spawn(async move {
+        while let Some(data) = rx.recv().await {
+            if stdin.write_all(&data).await.is_err() {
+                return;
+            }
+            if stdin.flush().await.is_err() {
+                return;
+            }
+        }
+    });
+    tx
+}
+
+struct PidTerminator {
+    pid: u32,
+}
+
+impl ChildTerminator for PidTerminator {
+    fn terminate(&mut self) {
+        let _ = process_group::terminate_process_group(self.pid);
+        let _ = process_group::kill_process_group_by_pid(self.pid);
+    }
+}
+
+fn spawn_reader<R>(mut reader: R, stream: Stream, output_tx: broadcast::Sender<OutputChunk>)
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut buffer = [0u8; 8192];
+        loop {
+            match reader.read(&mut buffer).await {
+                Ok(0) => return,
+                Ok(n) => {
+                    let chunk = OutputChunk { stream, data: buffer[..n].to_vec() };
+                    let _ = output_tx.send(chunk);
+                }
+                Err(_) => return,
+            }
+        }
+    });
+}
+
+fn spawn_exit_watcher(
+    mut child: Child,
+    exit_code: Arc<StdMutex<Option<i32>>>,
+    exit_notify: Arc<Notify>,
+) {
+    tokio::spawn(async move {
+        let code = match child.wait().await {
+            Ok(status) => Some(normalize_exit_code(status)),
+            Err(_) => Some(-1),
+        };
+
+        *lock_or_recover(&exit_code) = code;
+        exit_notify.notify_waiters();
+    });
+}
+
+fn normalize_exit_code(status: ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+
+    #[cfg(unix)]
+    if let Some(signal) = status.signal() {
+        return 128 + signal;
+    }
+
+    -1
+}
+
+fn drain_receiver(
+    receiver: &mut OutputReceiver,
+    stdout: &mut HeadTailBuffer,
+    stderr: &mut HeadTailBuffer,
+) {
+    receiver.drain_with(|chunk| push_output_chunk(chunk, stdout, stderr));
+}
+
+fn push_output_chunk(chunk: OutputChunk, stdout: &mut HeadTailBuffer, stderr: &mut HeadTailBuffer) {
+    let OutputChunk { stream, data } = chunk;
+    match stream {
+        Stream::Stdout => stdout.push_chunk(data),
+        Stream::Stderr => stderr.push_chunk(data),
+    }
+}

--- a/crates/exec/src/tests.rs
+++ b/crates/exec/src/tests.rs
@@ -1,0 +1,251 @@
+use crate::{
+    CommandOptions, ExecRequest, PollRequest, PoolConfig, ProcessPool, StdinRequest, Stream,
+    run_with_timeout, subprocess,
+};
+use anyhow::Result;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::broadcast::error::{RecvError, TryRecvError};
+use tokio::time::{sleep, timeout};
+
+fn test_pool_config() -> PoolConfig {
+    PoolConfig {
+        max_processes: 8,
+        max_output_bytes: 16 * 1024,
+        default_yield_ms: 25,
+        max_yield_ms: 2_000,
+        background_timeout_ms: 5_000,
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn spawn_captures_tagged_stdout_and_stderr() -> Result<()> {
+    let cwd = tempdir()?;
+    let args = vec!["-c".to_string(), "printf 'hello'; printf 'error' >&2".to_string()];
+
+    let (handle, mut rx) =
+        subprocess::spawn(CommandOptions::new("sh", cwd.path()).args(args)).await?;
+    timeout(Duration::from_secs(5), handle.wait_for_exit()).await?;
+    sleep(Duration::from_millis(50)).await;
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    loop {
+        match rx.try_recv() {
+            Ok(chunk) => match chunk.stream {
+                Stream::Stdout => stdout.extend_from_slice(&chunk.data),
+                Stream::Stderr => stderr.extend_from_slice(&chunk.data),
+            },
+            Err(TryRecvError::Empty | TryRecvError::Closed) => break,
+            Err(TryRecvError::Lagged(_)) => continue,
+        }
+    }
+
+    assert_eq!(stdout, b"hello".to_vec());
+    assert_eq!(stderr, b"error".to_vec());
+    assert_eq!(handle.exit_code(), Some(0));
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn write_stdin_round_trip() -> Result<()> {
+    let cwd = tempdir()?;
+    let args = vec!["-c".to_string(), "read line; printf 'seen:%s' \"$line\"".to_string()];
+
+    let (handle, mut rx) =
+        subprocess::spawn(CommandOptions::new("sh", cwd.path()).args(args)).await?;
+    handle.write_stdin(b"ping\n").await?;
+    timeout(Duration::from_secs(5), handle.wait_for_exit()).await?;
+    sleep(Duration::from_millis(50)).await;
+
+    let mut stdout = Vec::new();
+    while let Ok(chunk) = rx.try_recv() {
+        if chunk.stream == Stream::Stdout {
+            stdout.extend_from_slice(&chunk.data);
+        }
+    }
+
+    assert_eq!(stdout, b"seen:ping".to_vec());
+    assert_eq!(handle.exit_code(), Some(0));
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn spawn_no_stdin_rejects_stdin_writes() -> Result<()> {
+    let cwd = tempdir()?;
+    let args = vec!["-c".to_string(), "echo done".to_string()];
+
+    let (handle, _) =
+        subprocess::spawn(CommandOptions::new("sh", cwd.path()).args(args).no_stdin()).await?;
+    let error = handle.write_stdin(b"input").await.expect_err("stdin should be unavailable");
+
+    assert!(error.to_string().contains("stdin"));
+    timeout(Duration::from_secs(5), handle.wait_for_exit()).await?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn terminate_stops_long_running_process() -> Result<()> {
+    let cwd = tempdir()?;
+    let args = vec!["-c".to_string(), "sleep 30".to_string()];
+
+    let (handle, _) = subprocess::spawn(CommandOptions::new("sh", cwd.path()).args(args)).await?;
+    sleep(Duration::from_millis(200)).await;
+
+    handle.terminate();
+    timeout(Duration::from_secs(5), handle.wait_for_exit()).await?;
+
+    assert!(handle.has_exited());
+    assert_ne!(handle.exit_code(), Some(0));
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn background_file_ipc_pattern() -> Result<()> {
+    let cwd = tempdir()?;
+    let args =
+        vec!["-c".to_string(), "for i in 1 2 3; do echo line$i; sleep 0.05; done".to_string()];
+
+    let (handle, mut rx) =
+        subprocess::spawn(CommandOptions::new("sh", cwd.path()).args(args)).await?;
+    let output_path = cwd.path().join("output.log");
+    let output_path_for_task = output_path.clone();
+
+    let file_task = tokio::spawn(async move {
+        let mut file = tokio::fs::File::create(&output_path_for_task).await?;
+        loop {
+            match rx.recv().await {
+                Ok(chunk) => file.write_all(&chunk.data).await?,
+                Err(RecvError::Closed) => break,
+                Err(RecvError::Lagged(_)) => continue,
+            }
+        }
+        file.flush().await?;
+        Ok::<(), anyhow::Error>(())
+    });
+
+    timeout(Duration::from_secs(5), handle.wait_for_exit()).await?;
+    drop(handle);
+    let _ = timeout(Duration::from_secs(5), file_task).await?;
+
+    let content = tokio::fs::read_to_string(&output_path).await?;
+    assert!(content.contains("line1"));
+    assert!(content.contains("line2"));
+    assert!(content.contains("line3"));
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_with_timeout_collects_output() -> Result<()> {
+    let cwd = tempdir()?;
+    let args = vec!["-c".to_string(), "printf 'hello'; printf 'error' >&2".to_string()];
+
+    let result = run_with_timeout(
+        CommandOptions::new("sh", cwd.path()).args(args),
+        Duration::from_secs(5),
+        1024,
+    )
+    .await?;
+
+    assert_eq!(result.stdout, b"hello".to_vec());
+    assert_eq!(result.stderr, b"error".to_vec());
+    assert_eq!(result.stdout_omitted_bytes, 0);
+    assert_eq!(result.stderr_omitted_bytes, 0);
+    assert_eq!(result.exit_code, Some(0));
+    assert!(!result.timed_out);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_with_timeout_terminates_process() -> Result<()> {
+    let cwd = tempdir()?;
+    let args = vec!["-c".to_string(), "echo start; sleep 30".to_string()];
+
+    let result = run_with_timeout(
+        CommandOptions::new("sh", cwd.path()).args(args),
+        Duration::from_millis(100),
+        1024,
+    )
+    .await?;
+
+    assert_eq!(result.stdout, b"start\n".to_vec());
+    assert!(result.timed_out);
+    assert_eq!(result.exit_code, None);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn run_with_timeout_tracks_stdout_and_stderr_truncation_independently() -> Result<()> {
+    let cwd = tempdir()?;
+    let args = vec!["-c".to_string(), "printf 'abcdefghij'; printf 'klmnopqrst' >&2".to_string()];
+
+    let result = run_with_timeout(
+        CommandOptions::new("sh", cwd.path()).args(args),
+        Duration::from_secs(5),
+        6,
+    )
+    .await?;
+
+    assert_eq!(result.stdout, b"abchij".to_vec());
+    assert_eq!(result.stderr, b"klmrst".to_vec());
+    assert_eq!(result.stdout_omitted_bytes, 4);
+    assert_eq!(result.stderr_omitted_bytes, 4);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn process_pool_supports_background_polling() -> Result<()> {
+    let cwd = tempdir()?;
+    let pool = ProcessPool::new(test_pool_config());
+    let request = ExecRequest::new(
+        CommandOptions::new("sh", cwd.path())
+            .args(["-c".to_string(), "echo started; sleep 0.4; echo finished".to_string()]),
+    )
+    .with_yield_time_ms(25);
+
+    let initial = pool.exec(request).await?;
+    assert!(String::from_utf8_lossy(&initial.output).contains("started"));
+    let process_id = initial.process_id.expect("process should still be running");
+
+    let later = pool.poll_output(PollRequest::new(&process_id).with_yield_time_ms(1_000)).await?;
+
+    assert!(String::from_utf8_lossy(&later.output).contains("finished"));
+    assert_eq!(later.process_id, None);
+    assert_eq!(later.exit_code, Some(0));
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn process_pool_supports_interactive_stdin() -> Result<()> {
+    let cwd = tempdir()?;
+    let pool = ProcessPool::new(test_pool_config());
+    let request = ExecRequest::new(CommandOptions::new("sh", cwd.path()).args([
+        "-c".to_string(),
+        "while IFS= read -r line; do printf 'seen:%s\\n' \"$line\"; done".to_string(),
+    ]))
+    .with_yield_time_ms(25);
+
+    let initial = pool.exec(request).await?;
+    assert!(initial.output.is_empty());
+    let process_id = initial.process_id.expect("interactive process should stay alive");
+
+    let echoed =
+        pool.write_stdin(StdinRequest::new(&process_id, b"ping\n").with_yield_time_ms(500)).await?;
+
+    assert!(String::from_utf8_lossy(&echoed.output).contains("seen:ping"));
+    assert_eq!(echoed.process_id, Some(process_id.clone()));
+
+    pool.kill(&process_id).await?;
+    Ok(())
+}

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ante-protocol"
+version = "0.1.0"
+edition = "2024"
+description = "Protocol DTOs and wire messages for Ante"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+ulid = "1.2"

--- a/crates/protocol/src/id.rs
+++ b/crates/protocol/src/id.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Copy)]
+pub struct Id {
+    prefix: [u8; Self::PREFIX_SIZE],
+    id: Ulid,
+}
+
+impl Id {
+    pub const PREFIX_SIZE: usize = 4;
+
+    pub fn new<S: AsRef<str>>(id: S) -> Self {
+        Self { prefix: Self::clamp_prefix(id), id: Ulid::new() }
+    }
+
+    fn clamp_prefix<S: AsRef<str>>(id: S) -> [u8; Self::PREFIX_SIZE] {
+        let mut prefix = [0u8; Self::PREFIX_SIZE];
+        let bytes = id.as_ref().as_bytes();
+        let len = std::cmp::min(bytes.len(), Self::PREFIX_SIZE);
+        prefix[..len].copy_from_slice(&bytes[..len]);
+        prefix
+    }
+
+    pub fn op() -> Self {
+        Self::new("op")
+    }
+
+    pub fn evt() -> Self {
+        Self::new("evt")
+    }
+
+    pub fn ses() -> Self {
+        Self::new("ses")
+    }
+
+    pub fn step() -> Self {
+        Self::new("step")
+    }
+}
+
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for &b in self.prefix.iter().take_while(|&&b| b != 0) {
+            write!(f, "{}", b as char)?;
+        }
+        write!(f, "_{}", self.id)
+    }
+}
+
+impl std::fmt::Debug for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl Serialize for Id {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Id {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+impl std::str::FromStr for Id {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (prefix_str, ulid_str) =
+            s.split_once('_').ok_or_else(|| anyhow::anyhow!("Missing separator"))?;
+        let id = Ulid::from_string(ulid_str).map_err(|_| anyhow::anyhow!("Invalid ULID"))?;
+        Ok(Self { prefix: Self::clamp_prefix(prefix_str), id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_id_serde_roundtrip() {
+        let id = Id::new("evt");
+        let serialized = serde_json::to_string(&id).expect("serialize id");
+        assert_eq!(serialized, format!("\"{id}\""));
+
+        let deserialized: Id = serde_json::from_str(&serialized).expect("deserialize id");
+        assert_eq!(deserialized, id);
+    }
+
+    #[test]
+    fn test_id_from_str() {
+        let id = Id::new("ses");
+        let parsed = Id::from_str(&id.to_string()).expect("parse id");
+        assert_eq!(parsed, id);
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod id;
+pub mod msg;
+
+pub use id::Id;
+pub use msg::*;

--- a/crates/protocol/src/msg.rs
+++ b/crates/protocol/src/msg.rs
@@ -1,0 +1,560 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::id::Id;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventMsg {
+    pub timestamp: DateTime<Utc>,
+    pub id: Id,
+    pub event: Evt,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<Id>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpMsg {
+    pub op: Op,
+    pub id: Id,
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum Op {
+    StartSession(SessionConfig),
+    UpdateSession(SessionUpdate),
+    Interrupt,
+    UserInput(String),
+    Steer(String),
+    ApprovalResponse { turn_id: Id, responses: Vec<(String, ReviewDecision)> },
+    SlashCommand { name: String, args: String },
+    OfflineMode(OfflineModeOp),
+    Shutdown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Evt {
+    SessionStart(Box<SessionInitialized>),
+    SessionUpdated(Box<SessionInitialized>),
+    ExtensionRefreshed(Box<ExtensionRefreshed>),
+    SessionEnd,
+    AgentMessage(String),
+    Thinking(String),
+    MessageDelta(String),
+    ThinkingDelta(String),
+    Info(String),
+    Error(String),
+    ToolStart(ToolUse),
+    ToolUpdate(ToolUpdate),
+    ToolEnd(ToolEnd),
+    CompactStart,
+    CompactEnd,
+    TurnStart { turn_id: Id },
+    TurnPause { turn_id: Id, reason: TurnPauseReason },
+    TurnEnd { turn_id: Id, status: TurnEndStatus },
+    UsageUpdate { usage: Usage },
+    OfflineMode(OfflineModeEvt),
+    Goodbye,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TurnPauseReason {
+    Approval { tools: Vec<ToolUse>, message: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TurnEndStatus {
+    Completed,
+    Interrupted {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolUpdate {
+    pub tool_use_id: String,
+    pub seq: u64,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ToolEndStatus {
+    Completed,
+    Cancelled,
+    Denied,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolEnd {
+    pub tool_use_id: String,
+    pub status: ToolEndStatus,
+    pub result_json: serde_json::Value,
+    pub is_error: bool,
+}
+
+impl ToolEnd {
+    pub fn tool_use_id(&self) -> &str {
+        &self.tool_use_id
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.is_error
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ReviewDecision {
+    Accept,
+    Skip,
+    AcceptForSession,
+    Abort,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillMetadata {
+    pub name: String,
+    pub description: Option<String>,
+    pub scope: Scope,
+    pub argument_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubagentMetadata {
+    pub name: String,
+    pub description: String,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionInitialized {
+    pub model: ModelSpec,
+    pub provider: ApiProvider,
+    pub session_id: Id,
+    pub cwd: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionUpdate {
+    pub model: ModelSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtensionRefreshed {
+    pub session_id: Id,
+    pub skills: Vec<SkillMetadata>,
+    pub subagents: Vec<SubagentMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OfflineModeOp {
+    Init,
+    InstallEngine,
+    UpgradeEngine,
+    SetModelDirectory { path: PathBuf },
+    LoadModel { model: OfflineModel, prefs: ModelPreferences },
+    StopServer,
+    AttachServer { port: u16, model_name: String },
+    KillLlamaServer,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OfflineModeEvt {
+    Init {
+        engine_status: EngineStatus,
+        system_caps: SystemCapabilities,
+        local_models: Vec<OfflineModel>,
+        verified_models: Vec<VerifiedModel>,
+        #[serde(default)]
+        upgrade_available: Option<(Option<u32>, u32)>,
+        #[serde(default)]
+        running_servers: Vec<RunningServer>,
+    },
+    InstallProgress {
+        progress: u8,
+        message: String,
+    },
+    Installed {
+        path: PathBuf,
+    },
+    ModelLoading {
+        model_name: String,
+        file_size_bytes: u64,
+    },
+    ServerReady {
+        port: u16,
+        model_name: String,
+        #[serde(default)]
+        server_pid: Option<u32>,
+    },
+    LlamaServerKilled,
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionConfig {
+    pub model: String,
+    pub provider: String,
+    pub policy: Option<PermissionMode>,
+    pub streaming: bool,
+    pub system_prompt: Option<String>,
+    pub append_system_prompt: Option<String>,
+    pub allowed_tools: Option<Vec<String>>,
+    pub disallowed_tools: Option<Vec<String>>,
+    pub cwd: Option<PathBuf>,
+}
+
+impl SessionConfig {
+    pub fn default_streaming_enabled() -> bool {
+        std::env::var("ANTE_DISABLE_STREAMING").is_err()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolUse {
+    pub id: String,
+    pub name: String,
+    pub args: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelSpec {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequences: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<Thinking>,
+}
+
+impl ModelSpec {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            description: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            max_tokens: None,
+            stop_sequences: None,
+            thinking: None,
+            context_limit: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Copy, PartialEq)]
+pub enum Thinking {
+    Disabled,
+    Enabled,
+    Deep,
+    Max,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default, Copy)]
+#[serde(default)]
+pub struct Usage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub enum WireStyle {
+    #[default]
+    AnthropicMessage,
+    OpenAiCompatible,
+    OpenAiResponse,
+    Gemini,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct ApiProvider {
+    pub name: String,
+    pub display_name: String,
+    pub base_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth: Option<AuthConfig>,
+    pub wire_style: WireStyle,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_headers: Option<HashMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub preferred_models: Vec<ModelSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthConfig {
+    Bearer {
+        #[serde(flatten)]
+        credential: CredentialRef,
+    },
+    Header {
+        name: String,
+        #[serde(flatten)]
+        credential: CredentialRef,
+    },
+    Query {
+        name: String,
+        #[serde(flatten)]
+        credential: CredentialRef,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialRef {
+    EnvKey(String),
+    #[serde(rename = "oauth_preset")]
+    OAuthPreset(OAuthPresetId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OAuthPresetId {
+    Anthropic,
+    #[serde(rename = "openai", alias = "open_ai")]
+    OpenAi,
+    Antix,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionMode {
+    #[default]
+    Default,
+    Yolo,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum Scope {
+    Project,
+    User,
+    System,
+    Agent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunningServer {
+    pub port: u16,
+    pub model_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OfflineModel {
+    pub file_name: String,
+    pub file_size_bytes: u64,
+    #[serde(default)]
+    pub kv_cache_bytes_per_token: u64,
+    pub source: ModelSource,
+    #[serde(default = "default_context_window")]
+    pub context_window: u32,
+    #[serde(default = "default_shard_count")]
+    pub shard_count: u32,
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+fn default_shard_count() -> u32 {
+    1
+}
+
+fn default_context_window() -> u32 {
+    32768
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ModelSource {
+    Local(PathBuf),
+    Verified { repo: String, url: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelPreferences {
+    pub model_id: String,
+    pub context_window: u32,
+    pub thinking_enabled: bool,
+    pub temperature: Option<f32>,
+    #[serde(default)]
+    pub last_used: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SystemCapabilities {
+    pub total_ram_mb: u64,
+    pub available_ram_mb: u64,
+    pub gpu_devices: Vec<GpuDevice>,
+    pub total_vram_mb: u64,
+    pub available_vram_mb: u64,
+    #[serde(default)]
+    pub is_unified_memory: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GpuDevice {
+    pub index: u32,
+    pub name: String,
+    pub vram_mb: u64,
+    pub compute_capability: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EngineStatus {
+    Installed { server_path: PathBuf, cli_path: PathBuf },
+    NotInstalled,
+    Installing { progress: u8, message: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifiedModel {
+    pub name: String,
+    pub repo: String,
+    pub filename: String,
+    pub context_window: u32,
+    pub file_size_mb: u64,
+    pub kv_cache_bytes_per_token: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ApiProvider, EngineStatus, Evt, Id, ModelSource, ModelSpec, OfflineModeEvt, OfflineModel,
+        Op, SessionInitialized, SessionUpdate, SystemCapabilities, VerifiedModel,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn compact_events_serde_roundtrip() {
+        let compact_start =
+            serde_json::to_string(&Evt::CompactStart).expect("serialize CompactStart");
+        let compact_end = serde_json::to_string(&Evt::CompactEnd).expect("serialize CompactEnd");
+
+        assert_eq!(compact_start, "\"CompactStart\"");
+        assert_eq!(compact_end, "\"CompactEnd\"");
+
+        assert!(matches!(
+            serde_json::from_str::<Evt>(&compact_start).expect("deserialize CompactStart"),
+            Evt::CompactStart
+        ));
+        assert!(matches!(
+            serde_json::from_str::<Evt>(&compact_end).expect("deserialize CompactEnd"),
+            Evt::CompactEnd
+        ));
+    }
+
+    #[test]
+    fn session_update_op_serde_roundtrip() {
+        let op = Op::UpdateSession(SessionUpdate {
+            model: ModelSpec {
+                name: "gpt-5.4".to_string(),
+                temperature: Some(0.2),
+                ..ModelSpec::new("gpt-5.4".to_string())
+            },
+        });
+
+        let json = serde_json::to_string(&op).expect("serialize UpdateSession");
+        let decoded = serde_json::from_str::<Op>(&json).expect("deserialize UpdateSession");
+
+        assert!(matches!(
+            decoded,
+            Op::UpdateSession(SessionUpdate { model })
+                if model.name == "gpt-5.4" && model.temperature == Some(0.2)
+        ));
+    }
+
+    #[test]
+    fn session_updated_event_serde_roundtrip() {
+        let session_id = Id::new("ses");
+        let event = Evt::SessionUpdated(Box::new(SessionInitialized {
+            model: ModelSpec::new("claude-sonnet-4-6".to_string()),
+            provider: ApiProvider::default(),
+            session_id,
+            cwd: PathBuf::from("/tmp/session-updated"),
+        }));
+
+        let json = serde_json::to_string(&event).expect("serialize SessionUpdated");
+        let decoded = serde_json::from_str::<Evt>(&json).expect("deserialize SessionUpdated");
+
+        assert!(matches!(
+            decoded,
+            Evt::SessionUpdated(payload)
+                if payload.model.name == "claude-sonnet-4-6"
+                    && payload.session_id == session_id
+                    && payload.cwd == std::path::Path::new("/tmp/session-updated")
+        ));
+    }
+
+    #[test]
+    fn offline_mode_event_serde_roundtrip() {
+        let event = Evt::OfflineMode(OfflineModeEvt::Init {
+            engine_status: EngineStatus::Installing {
+                progress: 40,
+                message: "installing".to_string(),
+            },
+            system_caps: SystemCapabilities {
+                total_ram_mb: 32768,
+                available_ram_mb: 16384,
+                gpu_devices: Vec::new(),
+                total_vram_mb: 0,
+                available_vram_mb: 0,
+                is_unified_memory: true,
+            },
+            local_models: vec![OfflineModel {
+                file_name: "model.gguf".to_string(),
+                file_size_bytes: 1024,
+                kv_cache_bytes_per_token: 256,
+                source: ModelSource::Local(PathBuf::from("/models/model.gguf")),
+                context_window: 32768,
+                shard_count: 1,
+                display_name: Some("Local Model".to_string()),
+            }],
+            verified_models: vec![VerifiedModel {
+                name: "Verified Model".to_string(),
+                repo: "org/model".to_string(),
+                filename: "verified.gguf".to_string(),
+                context_window: 65536,
+                file_size_mb: 4096,
+                kv_cache_bytes_per_token: 1024,
+            }],
+            upgrade_available: Some((Some(8030), 8038)),
+            running_servers: Vec::new(),
+        });
+
+        let json = serde_json::to_string(&event).expect("serialize OfflineModeEvt::Init");
+        let decoded = serde_json::from_str::<Evt>(&json).expect("deserialize OfflineModeEvt::Init");
+
+        assert!(matches!(
+            decoded,
+            Evt::OfflineMode(OfflineModeEvt::Init {
+                upgrade_available: Some((Some(8030), 8038)),
+                ..
+            })
+        ));
+    }
+}


### PR DESCRIPTION
Automated sync of `crates/` from `ante-internal`.

Guardrails enabled:
- Explicit source→target mapping (`crates` → `crates`)
- Out-of-scope path change blocker
- Basic secret-pattern scan