### PR TITLE
Update docs for CLI, session resume, and protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Docker resource usage across 20 parallel tasks (Ante vs Claude Code vs Opencode)
 
 ![Resource Usage Comparison](docs-site/static/assets/compare_animated.gif)
 
-Across 20 parallel tasks, Ante uses **~7× less peak memory**, **~9× less average CPU**, and generates **~5× less total disk I/O** than Claude Code — while completing the same workload. See the [full comparison table](docs/assets/compare_table.md) for detailed CPU, memory, disk, and I/O metrics.
+Across 20 parallel tasks, Ante uses **~7× less peak memory**, **~9× less average CPU**, and generates **~5× less total disk I/O** than Claude Code — while completing the same workload. See the [benchmark details](docs-site/docs/benchmarks/eval.mdx) for the evaluation methodology and results.
 
 ## Quick Start
 
@@ -139,7 +139,7 @@ On the high level, it has most of your favorite features (Multi-agents, skills, 
 - You only need a llm provider configured to run it. Actually if you have the hardware, you don't even need a llm provider because Ante natively support private inference engine. 
 
 - This resulted in ~15MB self-contained binary and multi-agent orchestration designed to run hundreds of replicas in parallel at scale.
-See the [resource usage comparison](docs/assets/compare_table.md) across 20 parallel tasks for concrete numbers.
+See the [benchmark details](docs-site/docs/benchmarks/eval.mdx) across 20 parallel tasks for concrete numbers.
 
 - No vendor lock-ins, not even ourself. You don't need an account and can reuse your favorite api credentials. 
 

--- a/docs-site/docs/concepts/protocol.mdx
+++ b/docs-site/docs/concepts/protocol.mdx
@@ -113,6 +113,20 @@ Update the active session without restarting it (e.g. switch models mid-session)
 |---|---|---|
 | `model` | `ModelSpec` | New model specification to use |
 
+### ResumeSession
+
+Resume a previously persisted session by its ID. The daemon restores the conversation history, re-discovers extensions, and replays recent events so the client can rebuild its view.
+
+```json
+{ "op": { "ResumeSession": { "session_id": "ses_01ARZ..." } }, "id": "op_..." }
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `session_id` | `Id` | The session identifier to resume |
+
+On success the daemon emits `SessionEnd` for the current session (if any), then `SessionStart` and `ExtensionRefreshed` for the resumed session, followed by up to 200 replayed historical events. On failure it emits an `Error` event.
+
 ### Steer
 
 Provide additional guidance to the agent during an active turn without starting a new one.

--- a/docs-site/docs/configuration/preference.mdx
+++ b/docs-site/docs/configuration/preference.mdx
@@ -59,6 +59,7 @@ Settings can be overridden per-session via CLI flags.
 | `MODEL_TOP_P` | Override model top_p sampling parameter (float) |
 | `MODEL_THINKING` | Override thinking mode (`none`, `enabled`, `deep`, `max`). These map to the protocol-level values `Disabled`, `Enabled`, `Deep`, `Max` respectively |
 | `MODEL_MAX_TOKENS` | Override max output tokens (integer) |
+| `MODEL_CONTEXT_LIMIT` | Override max context window size (integer) |
 | `ANTE_LOCAL_PROVIDER_PORT` | Override the local provider port (default: 8080) |
 | `ANTE_HOME` | Override the home config directory (default: `~/.ante`) |
 | `ANTE_DISABLE_STREAMING` | Disable streaming responses in TUI mode |
@@ -71,6 +72,7 @@ Settings can be overridden per-session via CLI flags.
 ~/.ante/
 ├── settings.json      # User preferences
 ├── catalog.json       # Custom provider/model catalog
+├── sessions/          # Persisted sessions (for /resume)
 ├── skills/            # User-level skills
 └── agents/            # User-level sub-agents
 ```

--- a/docs-site/docs/start/quickstart.mdx
+++ b/docs-site/docs/start/quickstart.mdx
@@ -49,7 +49,7 @@ ante --provider openai --model gpt-5.4 -p "refactor this function"
 
 ```bash
 # YOLO mode — auto-approve all tool calls
-ante --yolo "fix all clippy warnings"
+ante --yolo -p "fix all clippy warnings"
 ```
 
 ### Run as a server

--- a/docs-site/docs/usage/headless.mdx
+++ b/docs-site/docs/usage/headless.mdx
@@ -53,6 +53,7 @@ ante [OPTIONS] [--prompt <PROMPT>]
 | `--allowed-tools <TOOLS>...` | Only allow these tools (space-separated) |
 | `--disallowed-tools <TOOLS>...` | Disallow these tools (space-separated) |
 | `--check` | Run a verification pass after the main task completes |
+| `--simple-agent` | Simple agent mode — uses a minimal system prompt with `PTY`, `ImageRead`, and `WebSearch` tools |
 
 ## Output formats
 
@@ -92,6 +93,16 @@ The verification pass will:
 1. Review what was accomplished against the original request
 2. Complete anything missing or incomplete
 3. Optimize where possible without affecting correctness
+
+## Simple agent mode
+
+The `--simple-agent` flag starts Ante with a minimal system prompt and a reduced tool set (`PTY`, `ImageRead`, `WebSearch`). This is useful for lightweight automation where you don't need the full coding agent:
+
+```bash
+ante --simple-agent -p "take a screenshot and describe what you see"
+```
+
+If you also pass `--system-prompt` or `--allowed-tools`, those take precedence over the simple-agent defaults.
 
 ## Context enrichment
 

--- a/docs-site/docs/usage/tui.mdx
+++ b/docs-site/docs/usage/tui.mdx
@@ -53,6 +53,7 @@ The TUI supports built-in slash commands for common actions:
 | `/model` | Open model selector |
 | `/offline-mode` | Open offline model selector |
 | `/welcome` | Show onboarding/welcome dialog |
+| `/resume` | Resume a previous session in this directory |
 | `/statusline` | Configure the status line |
 
 :::note
@@ -60,6 +61,28 @@ Some commands are "visible" (appear in conversation history) and others are "sil
 :::
 
 Skills also appear as slash commands with scope indicators: `[p]` for project-level, `[u]` for user-level, `[s]` for system-level, and `[a]` for agent-level skills.
+
+## Session resume
+
+Ante persists every session to disk. Use `/resume` to pick up a previous conversation where you left off.
+
+### How it works
+
+1. Type `/resume` to open the session picker
+2. Browse sessions scoped to the current working directory — each entry shows the first message, model, message count, and relative time
+3. Press **Enter** to select, or **Esc** to cancel
+
+On resume, Ante:
+- Restores the full conversation history
+- Re-discovers agents and skills in the project directory
+- Refreshes system prompts and tool definitions (so new features are available)
+- Replays up to 200 recent events so the TUI rebuilds the conversation view
+
+Sessions are stored in `~/.ante/sessions/{session_id}/` with atomic writes for crash safety.
+
+:::note
+Session resume is a TUI-only feature — it is not available in headless mode.
+:::
 
 ## Keyboard shortcuts
 


### PR DESCRIPTION
## Summary
- Document `--simple-agent` CLI flag in headless mode docs
- Document session resume feature (`/resume` command, `ResumeSession` protocol op, session persistence)
- Add `MODEL_CONTEXT_LIMIT` env var to preferences
- Fix invalid quickstart example (missing `-p` flag)
- Add `sessions/` directory to `~/.ante/` structure

## Test plan
- [ ] Verify docs site builds without errors
- [ ] Review each changed doc page for accuracy