### PR TITLE
fix(navbar): remove duplicate Ante tab

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -69,12 +69,6 @@ const config: Config = {
       items: [
         {
           type: 'docSidebar',
-          sidebarId: 'docs',
-          position: 'left',
-          label: 'Ante',
-        },
-        {
-          type: 'docSidebar',
           sidebarId: 'antix',
           position: 'left',
           label: 'Antix',


### PR DESCRIPTION
## Summary
- The navbar title/logo already links to the Ante docs, so the first `Ante` nav item was redundant next to `Antix`.
- Removes that duplicate item from `docs-site/docusaurus.config.ts`.

## Test plan
- [x] `npm start` locally — navbar shows only the `Ante` logo/title plus the `Antix` tab.