### PR TITLE
docs: refresh CLI entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Ante is an AI-native, cloud-native, local-first agent runtime built by [Antigma 
 - **Native local models** — Built-in local inference integration. No API keys, no internet, no data leaving your device.
 - **Zero vendor lock-in** — Bring your own API key or local model. Switch between 12+ providers freely. No account required.
 - **Client-daemon architecture** — Run as an interactive TUI, headless CLI, or long-lived server (`ante serve`).
+- **Channel integrations** — Run Ante as a Slack or Discord bot with `ante gateway`.
 - **Multi-agent orchestration** — Spawn sub-agents, coordinate complex tasks across independent, decentralized, or centralized architectures.
 - **Extensible** — Custom skills, sub-agents, and persistent memory across sessions.
 - **Benchmark proven** — Topped the Terminal Bench 1.0 and 2.0 leaderboards. Public, reproducible evals.
@@ -66,14 +67,30 @@ git diff | ante -p "review this for security issues"
 # Use a different provider
 ante --provider openai --model gpt-5.4 -p "refactor the database module"
 
-# Run fully offline with a local model
-ante --provider local -p "add error handling to src/main.rs"
+# Resume a saved session
+ante --resume ses_01ARZ3NDEKTSV4RRFFQ69G5FAV -p "now add tests"
+
+# Run fully offline with a local GGUF model
+ante --offline-model ~/.ante/models/Qwen3.5-9B-Q4_K_M.gguf \
+  -p "add error handling to src/main.rs"
 ```
 
 ### Server Mode
 
 ```sh
 ante serve
+```
+
+### Gateway Mode
+
+```sh
+ante gateway
+```
+
+### Update Ante
+
+```sh
+ante update
 ```
 
 ## Example Usages with TUI
@@ -192,6 +209,7 @@ For one-on-one agent interactions, runtime overhead like memory usage and I/O is
 But our vision is much bigger: millions of agents self-organizing and communicating at massive scale. At that point, even small inefficiencies get multiplied millions or billions of times, so runtime optimization becomes economically significant.
 </details>
 
+<details>
 <summary><b>Can I run Ante completely offline?</b></summary>
 
 Yes. Ante has a built-in llama.cpp engine that runs GGUF models locally. It handles engine installation, model discovery, and memory management automatically. No API keys or internet connection required.

--- a/docs-site/docs/start/overview.mdx
+++ b/docs-site/docs/start/overview.mdx
@@ -33,7 +33,7 @@ Built from the ground up in native Rust — a single self-contained binary with 
 
 ### How it works
 
-Ante runs as a client-daemon architecture. The daemon manages structured turn lifecycles — prompt, tool calls, confirmation, execution — channeling model power through a safe, predictable loop. The client can be an interactive TUI, a headless CLI, or an external process.
+Ante runs as a client-daemon architecture. The daemon manages structured turn lifecycles — prompt, tool calls, confirmation, execution — channeling model power through a safe, predictable loop. The client can be an interactive TUI, a headless CLI, an external process, or a channel bot via `ante gateway`.
 
 Architecturally, Ante is moving toward an agent-centric runtime where long-lived agents coordinate through message passing — an actor model with hierarchical supervision, isolated state, and clear ownership of resources per agent.
 
@@ -54,6 +54,12 @@ Ante is currently in **preview** and under active development. Expect breaking c
   </Card>
   <Card title="Interactive TUI" icon="terminal" href="/usage/tui">
     Learn to use the rich terminal interface.
+  </Card>
+  <Card title="Server Mode" icon="server" href="/usage/serve">
+    Drive Ante programmatically over stdio or WebSocket.
+  </Card>
+  <Card title="Gateway Mode" icon="message-square" href="/usage/gateway">
+    Run Ante as a Slack or Discord bot.
   </Card>
   <Card title="TUI Cookbook" icon="book-marked" href="/cookbook/login">
     Visual, step-by-step guides for common TUI workflows.


### PR DESCRIPTION
## Summary
- update README examples for `--resume`, `--offline-model`, `ante gateway`, and `ante update`
- surface gateway and server mode from the docs overview page
- fix the README offline FAQ details block markup

## Validation
- `git diff --check`
- `npm ci` in `docs-site`
- `npm run build` in `docs-site`

Note: `npm ci` reports existing dependency audit findings (8 moderate, 27 high), but install and build completed successfully.