### PR TITLE
docs: document ANTE_OPENAI_TRANSPORT and the OpenAI WS transport

### DIFF
--- a/docs-site/docs/configuration/preference.mdx
+++ b/docs-site/docs/configuration/preference.mdx
@@ -84,6 +84,7 @@ Settings can be overridden per-session via CLI flags.
 | `ANTE_LOCAL_PROVIDER_PORT` | Override the local provider port (default: 8080) |
 | `ANTE_HOME` | Override the home config directory (default: `~/.ante`) |
 | `ANTE_DISABLE_STREAMING` | Disable streaming responses in TUI mode |
+| `ANTE_OPENAI_TRANSPORT` | OpenAI Responses transport: `http_sse` (default) or `websocket_auto` (see [OpenAI transports](./providers#openai-transports)) |
 
 ## Directory structure
 

--- a/docs-site/docs/configuration/providers.mdx
+++ b/docs-site/docs/configuration/providers.mdx
@@ -93,6 +93,36 @@ ante --provider openai --model gpt-5.4
 
 Available models: `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.3-codex`, `gpt-5-mini`, `gpt-5-nano`
 
+#### OpenAI transports
+
+The `openai` and `openai-subscription` providers can stream responses two ways:
+
+| Transport | Endpoint | Default |
+|---|---|---|
+| `http_sse` (HTTP + SSE) | `https://api.openai.com/v1/responses` (or the subscription equivalent) | ✅ |
+| `websocket_auto` (persistent WebSocket) | `wss://.../v1/responses` | opt-in |
+
+WebSocket mode keeps one connection open per session and continues each turn with `previous_response_id` plus only the new input items. In long agentic tool loops this eliminates per-turn round-trip latency.
+
+Opt in via the process-scoped env var (default is `http_sse`):
+
+```bash
+ANTE_OPENAI_TRANSPORT=websocket_auto ante --provider openai --model gpt-5-mini
+```
+
+Accepted values: `http_sse`, `websocket_auto`. Unknown values warn and fall back to `http_sse`.
+
+Notes:
+
+- WS only engages on streaming turns (TUI sessions). Headless `--prompt` mode uses non-streaming `chat()` and bypasses WS by design.
+- Any transient WS failure (connect timeout, network blip) falls back to HTTP/SSE for that turn — users never see hard errors caused by the transport choice. Auth failures (`401`/`403`) flip the entire session to HTTP/SSE for the rest of its lifetime.
+- Works against both `api.openai.com` (API-key) and the ChatGPT subscription backend at `chatgpt.com/backend-api/codex`.
+- To verify which transport is active: in debug builds, toggle the debug panel (`Ctrl+L`) and check the **Info** tab for the `OpenAI Transport:` line. Otherwise grep your session log for `transport selected`:
+
+  ```bash
+  grep "transport selected" ~/.ante/logs/ante.*.log.*
+  ```
+
 ### Google Gemini
 
 ```bash

--- a/docs-site/docs/configuration/providers.mdx
+++ b/docs-site/docs/configuration/providers.mdx
@@ -102,7 +102,7 @@ The `openai` and `openai-subscription` providers can stream responses two ways:
 | `http_sse` (HTTP + SSE) | `https://api.openai.com/v1/responses` (or the subscription equivalent) | ✅ |
 | `websocket_auto` (persistent WebSocket) | `wss://.../v1/responses` | opt-in |
 
-WebSocket mode keeps one connection open per session and continues each turn with `previous_response_id` plus only the new input items. In long agentic tool loops this eliminates per-turn round-trip latency.
+WebSocket mode keeps one connection open per session and continues each turn with `previous_response_id` plus only the new input items. In long agentic tool loops this eliminates per-turn round-trip latency. See OpenAI's [WebSocket mode guide](https://developers.openai.com/api/docs/guides/websocket-mode) for the underlying protocol.
 
 Opt in via the process-scoped env var (default is `http_sse`):
 


### PR DESCRIPTION
## Why

Ante recently gained an opt-in WebSocket transport for the OpenAI Responses
provider, but the env var that enables it (`ANTE_OPENAI_TRANSPORT`) was
undocumented. This PR adds it to the docs in the two places people look:
the environment-variables table and the providers reference.

## What

- **`configuration/preference.mdx`** — adds `ANTE_OPENAI_TRANSPORT` to
  the env-vars table, with a link to the deeper explanation.
- **`configuration/providers.mdx`** — new "OpenAI transports" subsection
  under the OpenAI provider that covers:
  - the two transport modes (HTTP/SSE vs persistent WebSocket) and their
    endpoints,
  - what WebSocket mode does (one connection per session, incremental
    continuation via `previous_response_id`) and why it helps long
    agentic tool loops,
  - how to opt in with `ANTE_OPENAI_TRANSPORT=websocket_auto`,
  - behavioral notes: TUI-only by design (headless `--prompt` mode
    uses the non-streaming code path and bypasses WebSocket), transparent
    fallback to HTTP/SSE on transient failures, permanent fallback on
    auth errors,
  - support for both `api.openai.com` (API key) and the ChatGPT
    subscription backend,
  - how to verify the active transport (debug-panel info tab in debug
    builds, or `grep "transport selected" ~/.ante/logs/...`),
  - a link to OpenAI's official [WebSocket mode
    guide](https://developers.openai.com/api/docs/guides/websocket-mode)
    for the underlying protocol.

## Test plan

- [x] Both pages reviewed: markdown is well-formed and the in-doc
  anchor link (`./providers#openai-transports`) resolves.
- [ ] Build the site locally (`npm install && npm run build` from
  `docs-site/`) to confirm Docusaurus renders both pages without
  warnings.
- [ ] Visual review of the rendered pages.
