### PR TITLE
docs: fix cookbook guides' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ ante update --channel nightly
 </tr>
 </table>
 
-[See all cookbook guides](https://docs.antigma.ai/category/tui-cookbook)
+[See all cookbook guides](https://docs.antigma.ai/cookbook/login)
 
 ## Architecture
 
@@ -154,7 +154,7 @@ ante update --channel nightly
 ┌─────────────────────────────────────────────────────────────┐
 │                         Daemon                              │
 │                                                             │
-│   Session ──▶ Turn ──▶ Step                                 │
+│   Session ──▶ Turn ──▶ Step                                │
 │                                                             │
 │   ┌──────────┐  ┌──────────────┐  ┌───────────────────┐     │
 │   │  Tools   │  │  Permission  │  │  Skills / Agents  │     │


### PR DESCRIPTION
Replace the broken link to "See all cookbook guides" with the first entry of TUI Cookbook collection