### PR TITLE
docs: document ante rage/catalog and fix stale CLI flags + OpenRouter models

### DIFF
--- a/docs-site/docs/reference/catalog-reference.mdx
+++ b/docs-site/docs/reference/catalog-reference.mdx
@@ -135,17 +135,16 @@ ante --provider zai --model glm-5.1
 
 | Model | Description | Context |
 |---|---|---|
-| `anthropic/claude-opus-4.6` | Claude Opus 4.6 | 1M |
-| `anthropic/claude-sonnet-4.6` | Claude Sonnet 4.6 | 1M |
-| `google/gemini-3.1-pro-preview` | Gemini 3.1 Pro | 1M |
-| `openai/gpt-5.4-pro` | GPT-5.4 Pro | 1.05M |
-| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | 1M |
-| `deepseek/deepseek-v4-pro` | DeepSeek V4 Pro | 1M |
+| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | 1.05M |
+| `qwen/qwen3.7-max` | Qwen3.7 Max | 1M |
+| `moonshotai/kimi-k2.6` | Kimi K2.6 reasoning model with vision | 262K |
+| `minimax/minimax-m2.7` | MiniMax M2.7 model | 205K |
+| `deepseek/deepseek-v4-pro` | DeepSeek V4 Pro | 1.05M |
 
 Open Router also accepts any model from its [full model list](https://openrouter.ai/models) by id.
 
 ```bash
-ante --provider openrouter --model anthropic/claude-sonnet-4.6
+ante --provider openrouter --model deepseek/deepseek-v4-pro
 ```
 
 ### DeepSeek

--- a/docs-site/docs/reference/cli-reference.mdx
+++ b/docs-site/docs/reference/cli-reference.mdx
@@ -18,6 +18,7 @@ ante [OPTIONS] [COMMAND]
 | `ante gateway` | Run the Slack / Discord channel gateway. |
 | `ante update` | Check for the latest Ante release and install it if available. |
 | `ante rage` | Collect a redacted bug-report bundle (logs + environment) to share with the Ante team. |
+| `ante catalog` | Print the loaded provider/model catalog as JSON. |
 
 ## `ante`
 
@@ -65,24 +66,20 @@ Server mode exposes the Ante protocol over stdin/stdout by default, or over WebS
 
 | Flag | Description |
 |---|---|
-| `-m`, `--model <MODEL>` | Override the default model name. |
 | `--stdio` | Serve the JSONL protocol over stdin/stdout. This is the default transport. |
-| `--provider <PROVIDER>` | Override the API provider by catalog provider name. |
-| `--ws <ADDR>` | Serve the protocol over WebSocket on the given socket address. |
+| `--ws <ADDR>` | Serve the protocol over WebSocket on the given socket address. Conflicts with `--stdio`. |
 | `--offline-model <PATH>` | Load a local GGUF model at startup for offline mode. |
-| `--yolo` | Skip tool approval prompts for the session. |
-| `--system-prompt <PROMPT>` | Replace the default system prompt entirely. |
-| `--append-system-prompt <TEXT>` | Append content to the default system prompt. |
-| `--allowed-tools <TOOLS>...` | Only allow these tools. Values are space-separated. |
-| `--disallowed-tools <TOOLS>...` | Remove these tools from the session. Values are space-separated. |
 | `-h`, `--help` | Print command help. |
+
+:::note
+`serve` is session-agnostic, so it does not accept the session flags (`--model`, `--provider`, `--yolo`, `--system-prompt`, `--allowed-tools`, …). The connecting client configures those per session over the protocol.
+:::
 
 ### Examples
 
 ```bash
 ante serve
 ante serve --ws 127.0.0.1:8080
-ante serve --provider anthropic --model claude-sonnet-4-6
 ```
 
 ## `ante gateway`
@@ -98,13 +95,8 @@ Gateway mode connects Ante to Slack, Discord, or both using the channels config 
 | `--config <PATH>` | `~/.ante/channels.json` | Path to the channels configuration file. |
 | `--model <MODEL>` | `local` | Model to use for agent sessions. |
 | `--provider <PROVIDER>` | `local` | Provider to use for agent sessions. |
-| `--yolo` | - | Skip tool approval prompts for gateway sessions. |
 | `--output-format <FORMAT>` | `minimal` | Gateway stdout format: `json`, `human`, or `minimal`. |
-| `--system-prompt <PROMPT>` | - | Replace the default system prompt entirely. |
-| `--append-system-prompt <TEXT>` | - | Append content to the default system prompt. |
 | `--offline-model <PATH>` | - | Load a local GGUF model for all gateway conversations. |
-| `--allowed-tools <TOOLS>...` | - | Only allow these tools. Values are space-separated. |
-| `--disallowed-tools <TOOLS>...` | - | Remove these tools from the session. Values are space-separated. |
 | `-h`, `--help` | - | Print command help. |
 
 ### Examples
@@ -177,6 +169,21 @@ ante rage
 ante rage --output ./ante-bug.tar.gz
 ante rage --since 7d
 ante rage --no-compress
+```
+
+## `ante catalog`
+
+```bash
+ante catalog
+```
+
+Print the merged provider/model catalog (built-in presets plus `~/.ante/catalog.json`) to stdout as JSON, in the same schema the catalog file uses. Warnings for skipped catalog entries go to stderr, so stdout stays a clean JSON document that pipes into `jq`. See the [Catalog Reference](/reference/catalog-reference) for the schema.
+
+### Examples
+
+```bash
+ante catalog
+ante catalog | jq '.providers | keys'
 ```
 
 ## Output Formats


### PR DESCRIPTION
Sync the reference docs with the released **v0.preview.32** source.

## What changed

**`reference/cli-reference.mdx`**
- Add the `ante rage` subcommand (redacted bug-report bundle).
- Add the `ante catalog` subcommand (prints the merged provider/model catalog as JSON).
- Drop session flags from `ante serve` that it does not accept — it only takes `--stdio`, `--ws`, `--offline-model`. Session flags (`--model`, `--provider`, `--yolo`, `--system-prompt`, `--allowed-tools`, …) are intentionally not inherited by subcommands (`main.rs:39-41`).
- Drop the same session flags from `ante gateway`, keeping its real ones (`--config`, `--model`, `--provider`, `--output-format`, `--offline-model`).

**`reference/catalog-reference.mdx`**
- Replace the stale OpenRouter model table. It listed `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4.6`, `google/gemini-3.1-pro-preview`, `openai/gpt-5.4-pro` — none of which are in `openrouter_models()` anymore. Now lists the models actually shipped: `deepseek/deepseek-v4-flash`, `qwen/qwen3.7-max`, `moonshotai/kimi-k2.6`, `minimax/minimax-m2.7`, `deepseek/deepseek-v4-pro`.

## Verified accurate (no change needed)
- Permissions / storage / AGENTS.md docs already cover allow/ask/deny rules, "always allow" persistence, and global `~/.ante/AGENTS.md`.
- All other catalog model lists match source.
- The "structured turn errors" change is TUI-only; `Evt::Error` is still a plain string, so no protocol-surface change.